### PR TITLE
Update Shopify dev server start script and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,19 +14,13 @@
 $ yarn
 ```
 
-2. Log into Shopify store via CLI:
+2. Start the Shopify dev server.
 
 ```
-$ shopify login --store shopify-store
+$ yarn theme:start --store shopify-store
 ```
 
-3. Start the Shopify dev server.
-
-```
-$ yarn theme:start
-```
-
-4. Start the dev server in another terminal process.
+3. Start the dev server in another terminal process.
 
 ```
 $ yarn start

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"webpack:watch": "webpack watch",
 		"webpack:build": "webpack build",
 		"// THEME //": "",
-		"theme:start": "shopify theme serve",
+		"theme:start": "shopify theme dev",
 		"theme:push:all": "yarn build && shopify theme push",
 		"theme:push:theme": "yarn build && shopify theme push -x 'templates/*.json' -x 'config/settings_schema.json'",
 		"theme:pull:all": "shopify theme pull --nodelete",


### PR DESCRIPTION
Shopify deprecated `theme serve` in favor of `theme dev` so updating `package.json` and `README` to support
